### PR TITLE
fix: set margin for blog content on mobile phones

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,7 @@ layout: default
 		<div id="colorlib-main">
 			<section class="ftco-section ftco-no-pt ftco-no-pb">
 	    	<div class="container">
-	    		<div class="row d-flex">
+	    		<div class="row mx-1">
 	    			<div class="col-lg-8 px-md-5 py-5">
 	    				<div class="row pt-md-4">
 	    					<h1 class="mb-3"> {{ page.title }}</h1>


### PR DESCRIPTION
fix: set margin for blog content on mobile phones by setting the margin and removing flex character from blog content.